### PR TITLE
patch: get trackers

### DIFF
--- a/api/graphql/resolver/webtracker_resolvers.go
+++ b/api/graphql/resolver/webtracker_resolvers.go
@@ -132,7 +132,7 @@ func (r *queryResolver) Webtracker(ctx context.Context, id string) (*graphql_mod
 
 // Webtrackers is the resolver for the webtrackers field.
 func (r *queryResolver) Webtrackers(ctx context.Context) ([]*graphql_model.Webtracker, error) {
-	span, ctx := telemetry.StartGraphQLSpan(ctx, "queryResolver.Webtracker", graphql.GetOperationContext(ctx))
+	span, ctx := telemetry.StartGraphQLSpan(ctx, "queryResolver.Webtrackers", graphql.GetOperationContext(ctx))
 	defer span.Finish()
 
 	webtrackers, err := r.services.WebtrackerService.GetActiveWebtrackers(ctx)

--- a/internal/repository/webtracker.go
+++ b/internal/repository/webtracker.go
@@ -22,6 +22,7 @@ type WebTrackerRepository interface {
 	CreateWithTxn(ctx context.Context, txn *gorm.DB, tracker *models.WebTracker) error
 	GetByID(ctx context.Context, id string) (*models.WebTracker, error)
 	GetByDomain(ctx context.Context, id string) (*models.WebTracker, error)
+	GetTrackers(ctx context.Context) ([]models.WebTracker, error)
 	GetActiveTrackers(ctx context.Context) ([]models.WebTracker, error)
 	Update(ctx context.Context, record dto.WebTrackerUpdate) error
 	UpdateLastEventAt(ctx context.Context, trackerID string, timestamp time.Time) error
@@ -131,6 +132,28 @@ func (r *webTrackerRepository) GetByDomain(ctx context.Context, domain string) (
 	return &tracker, nil
 }
 
+func (r *webTrackerRepository) GetTrackers(ctx context.Context) ([]models.WebTracker, error) {
+	span, ctx := telemetry.StartPostgresSpan(ctx, "webTrackerRepository.GetTrackers")
+	defer span.Finish()
+
+	tenant := utils.GetTenantFromContext(ctx)
+	if tenant == "" {
+		err := leads_errors.ErrTenantMissing
+		span.TraceError(err)
+		return nil, err
+	}
+
+	var trackers []models.WebTracker
+	result := r.read.WithContext(ctx).
+		Where("tenant = ?", tenant).
+		Where("is_archived = ?", false).
+		Order("domain").
+		Find(&trackers)
+
+	span.LogKV("result.count", len(trackers))
+	return trackers, result.Error
+}
+
 // GetActiveTrackers retrieves all active non-archived WebTrackers
 func (r *webTrackerRepository) GetActiveTrackers(ctx context.Context) ([]models.WebTracker, error) {
 	span, ctx := telemetry.StartPostgresSpan(ctx, "webTrackerRepository.GetActiveTrackers")
@@ -148,7 +171,10 @@ func (r *webTrackerRepository) GetActiveTrackers(ctx context.Context) ([]models.
 		Where("tenant = ?", tenant).
 		Where("is_archived = ?", false).
 		Where("is_proxy_active = ?", true).
+		Order("domain").
 		Find(&trackers)
+
+	span.LogKV("result.count", len(trackers))
 	return trackers, result.Error
 }
 

--- a/services/webtracker/get_webtracker.go
+++ b/services/webtracker/get_webtracker.go
@@ -2,14 +2,64 @@ package webtracker
 
 import (
 	"context"
+	"github.com/pkg/errors"
 
 	"github.com/customeros/leads/internal/models"
 	"github.com/customeros/leads/internal/telemetry"
 )
+
+func (s *webtrackerService) IsCNAMEConfigured(ctx context.Context, webtrackerID string) (bool, error) {
+	span, ctx := telemetry.StartServiceSpan(ctx, "webtrackerService.IsCNAMEConfigured")
+	defer span.Finish()
+
+	trackerRecord, err := s.repositories.WebTracker.GetByID(ctx, webtrackerID)
+	if err != nil {
+		span.TraceError(err)
+		return false, err
+	}
+	if trackerRecord == nil {
+		err := errors.New("Cannot find webtracker")
+		span.TraceError(err)
+		return false, err
+	}
+
+	return trackerRecord.IsCNAMEConfigured, nil
+}
 
 func (s *webtrackerService) GetWebtrackerByOrigin(ctx context.Context, origin string) (*models.WebTracker, error) {
 	span, ctx := telemetry.StartServiceSpan(ctx, "webtrackerService.GetWebtrackerByOrigin")
 	defer span.Finish()
 
 	return s.repositories.WebTracker.GetByDomain(ctx, origin)
+}
+
+func (s *webtrackerService) GetWebtracker(ctx context.Context, webtrackerID string) (*models.WebTracker, error) {
+	span, ctx := telemetry.StartServiceSpan(ctx, "webtrackerService.GetWebtracker")
+	defer span.Finish()
+
+	trackerRecord, err := s.repositories.WebTracker.GetByID(ctx, webtrackerID)
+	if err != nil {
+		span.TraceError(err)
+		return nil, err
+	}
+	if trackerRecord == nil {
+		err := errors.New("Cannot find webtracker")
+		span.TraceError(err)
+		return nil, err
+	}
+	return trackerRecord, nil
+}
+
+func (s *webtrackerService) GetActiveWebtrackers(ctx context.Context) ([]models.WebTracker, error) {
+	span, ctx := telemetry.StartServiceSpan(ctx, "webtrackerService.GetActiveWebtrackers")
+	defer span.Finish()
+
+	return s.repositories.WebTracker.GetActiveTrackers(ctx)
+}
+
+func (s *webtrackerService) GetWebtrackers(ctx context.Context) ([]models.WebTracker, error) {
+	span, ctx := telemetry.StartServiceSpan(ctx, "webtrackerService.GetWebtrackers")
+	defer span.Finish()
+
+	return s.repositories.WebTracker.GetTrackers(ctx)
 }

--- a/services/webtracker/service.go
+++ b/services/webtracker/service.go
@@ -16,6 +16,7 @@ type WebtrackerService interface {
 	ArchiveWebtracker(ctx context.Context, webtrackerID string) error
 	GetWebtracker(ctx context.Context, webtrackerID string) (*models.WebTracker, error)
 	GetWebtrackerByOrigin(ctx context.Context, origin string) (*models.WebTracker, error)
+	GetWebtrackers(ctx context.Context) ([]models.WebTracker, error)
 	GetActiveWebtrackers(ctx context.Context) ([]models.WebTracker, error)
 	IsCNAMEConfigured(ctx context.Context, webtrackerID string) (bool, error)
 }

--- a/services/webtracker/update.go
+++ b/services/webtracker/update.go
@@ -48,24 +48,6 @@ func (s *webtrackerService) UpdateCNAMEHost(ctx context.Context, webtrackerID, c
 	return trackerRecord, nil
 }
 
-func (s *webtrackerService) IsCNAMEConfigured(ctx context.Context, webtrackerID string) (bool, error) {
-	span, ctx := telemetry.StartServiceSpan(ctx, "webtrackerService.IsCNAMEConfigured")
-	defer span.Finish()
-
-	trackerRecord, err := s.repositories.WebTracker.GetByID(ctx, webtrackerID)
-	if err != nil {
-		span.TraceError(err)
-		return false, err
-	}
-	if trackerRecord == nil {
-		err := errors.New("Cannot find webtracker")
-		span.TraceError(err)
-		return false, err
-	}
-
-	return trackerRecord.IsCNAMEConfigured, nil
-}
-
 func (s *webtrackerService) ArchiveWebtracker(ctx context.Context, webtrackerID string) error {
 	span, ctx := telemetry.StartServiceSpan(ctx, "webtrackerService.ArchiveWebtracker")
 	defer span.Finish()
@@ -82,28 +64,4 @@ func (s *webtrackerService) ArchiveWebtracker(ctx context.Context, webtrackerID 
 	}
 
 	return s.repositories.WebTracker.Archive(ctx, webtrackerID)
-}
-
-func (s *webtrackerService) GetWebtracker(ctx context.Context, webtrackerID string) (*models.WebTracker, error) {
-	span, ctx := telemetry.StartServiceSpan(ctx, "webtrackerService.GetWebtracker")
-	defer span.Finish()
-
-	trackerRecord, err := s.repositories.WebTracker.GetByID(ctx, webtrackerID)
-	if err != nil {
-		span.TraceError(err)
-		return nil, err
-	}
-	if trackerRecord == nil {
-		err := errors.New("Cannot find webtracker")
-		span.TraceError(err)
-		return nil, err
-	}
-	return trackerRecord, nil
-}
-
-func (s *webtrackerService) GetActiveWebtrackers(ctx context.Context) ([]models.WebTracker, error) {
-	span, ctx := telemetry.StartServiceSpan(ctx, "webtrackerService.GetActiveWebtrackers")
-	defer span.Finish()
-
-	return s.repositories.WebTracker.GetActiveTrackers(ctx)
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds method to retrieve all web trackers and refactors service methods for better organization.
> 
>   - **Behavior**:
>     - Adds `GetTrackers` method in `webTrackerRepository` to retrieve all non-archived web trackers ordered by domain.
>     - Modifies `GetActiveTrackers` in `webTrackerRepository` to include ordering by domain and logging of result count.
>     - Updates `Webtrackers` resolver in `webtracker_resolvers.go` to use `GetActiveWebtrackers` service method.
>   - **Services**:
>     - Adds `GetWebtrackers` method in `webtrackerService` to call `GetTrackers` from repository.
>     - Refactors `IsCNAMEConfigured`, `GetWebtracker`, and `GetActiveWebtrackers` methods to `get_webtracker.go` from `update.go`.
>   - **Misc**:
>     - Fixes telemetry span name in `Webtrackers` resolver from `Webtracker` to `Webtrackers`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fleads&utm_source=github&utm_medium=referral)<sup> for 5cfcf482831c2af7161f2dafde26f0f01506cfcc. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->