### PR TITLE
patch: get trackers including non-active

### DIFF
--- a/api/graphql/resolver/webtracker_resolvers.go
+++ b/api/graphql/resolver/webtracker_resolvers.go
@@ -135,7 +135,7 @@ func (r *queryResolver) Webtrackers(ctx context.Context) ([]*graphql_model.Webtr
 	span, ctx := telemetry.StartGraphQLSpan(ctx, "queryResolver.Webtrackers", graphql.GetOperationContext(ctx))
 	defer span.Finish()
 
-	webtrackers, err := r.services.WebtrackerService.GetActiveWebtrackers(ctx)
+	webtrackers, err := r.services.WebtrackerService.GetWebtrackers(ctx)
 	if err != nil {
 		span.TraceError(err)
 		return nil, err


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> `Webtrackers` resolver now retrieves all webtrackers, including non-active ones, in `webtracker_resolvers.go`.
> 
>   - **Behavior**:
>     - `Webtrackers` resolver in `webtracker_resolvers.go` now retrieves all webtrackers, including non-active ones, by calling `GetWebtrackers` instead of `GetActiveWebtrackers`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fleads&utm_source=github&utm_medium=referral)<sup> for bf621824daabb78ac5de1fbe81294817818424e8. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->