### PR TITLE
patch: deprecate nats session caching

### DIFF
--- a/api/handlers/website_events_handler.go
+++ b/api/handlers/website_events_handler.go
@@ -16,7 +16,7 @@ import (
 	"github.com/customeros/leads/internal/enum"
 	"github.com/customeros/leads/internal/telemetry"
 	"github.com/customeros/leads/internal/utils"
-	"github.com/customeros/leads/proto/mappers"
+	proto_mappers "github.com/customeros/leads/proto/mappers"
 	"github.com/customeros/leads/proto/pb"
 	"github.com/customeros/leads/services"
 )
@@ -51,8 +51,6 @@ type WebTrackerEvent struct {
 	ScreenResolution string               `json:"screenResolution"`
 }
 
-const REQUEST_TIMEOUT = 60 * time.Second
-
 func (h *WebsiteEventsHandler) Handle() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		span, ctx := telemetry.StartRestSpan(c.Request.Context(), "WebsiteEventsHandler.Handle")
@@ -67,6 +65,11 @@ func (h *WebsiteEventsHandler) Handle() gin.HandlerFunc {
 		tenant, webtrackerID, err := h.getTenantAndTrackerID(ctx, c.GetHeader("Origin"))
 		if err != nil {
 			span.TraceError(err)
+			c.JSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+			return
+		}
+		if tenant == "" || webtrackerID == "" {
+			span.TraceError(errors.New("tenant or webtrackerID not found"))
 			c.JSON(http.StatusForbidden, gin.H{"error": "forbidden"})
 			return
 		}

--- a/interfaces/web_event_processor.go
+++ b/interfaces/web_event_processor.go
@@ -1,0 +1,11 @@
+package interfaces
+
+import (
+	"context"
+
+	"github.com/customeros/leads/proto/pb"
+)
+
+type WebEventProcessor interface {
+	Process(ctx context.Context, webtrackerID string, event *pb.WebTrackerEvent)
+}

--- a/internal/models/websession.go
+++ b/internal/models/websession.go
@@ -16,6 +16,9 @@ type WebSession struct {
 	CompanyID string `gorm:"column:company_id;type:varchar(255);index;not null"`
 	IP        string `gorm:"column:ip;type:varchar(255)"`
 
+	// Session metadata
+	Active bool `gorm:"column:is_active;type:boolean;default:true"`
+
 	// Session timing
 	StartedAt       time.Time  `gorm:"column:started_at;type:timestamptz;not null;index"`
 	LastEventAt     *time.Time `gorm:"column:last_event_at;type:timestamptz;index"`
@@ -55,6 +58,7 @@ type WebSession struct {
 
 	// System fields
 	CreatedAt time.Time `gorm:"column:created_at;type:timestamptz;not null;default:now()"`
+	UpdatedAt time.Time `gorm:"column:updated_at;type:timestamptz;not null;default:now()"`
 }
 
 func (WebSession) TableName() string {

--- a/internal/nats/session_cache.go
+++ b/internal/nats/session_cache.go
@@ -12,6 +12,7 @@ import (
 )
 
 // SessionCache provides visitor lookup caching using NATS KV
+// Deprecated
 type SessionCache struct {
 	kv nats.KeyValue
 }

--- a/internal/repository/websession.go
+++ b/internal/repository/websession.go
@@ -23,6 +23,7 @@ type WebSessionRepository interface {
 	GetInactiveSessions(ctx context.Context) ([]*models.WebSession, error)
 	UpdateLastEvent(ctx context.Context, sessionID string, event enum.Events, timestamp time.Time) error
 	CloseSessionWithTxn(ctx context.Context, tx *gorm.DB, sessionID string) error
+	GetActiveSessionByTrackerAndVisitor(ctx context.Context, trackerID, visitorID string) (*models.WebSession, error)
 }
 
 // Implementation errors
@@ -196,4 +197,31 @@ func (r *webSessionRepository) UpdateLastEvent(ctx context.Context, sessionID st
 	}
 
 	return nil
+}
+
+func (r *webSessionRepository) GetActiveSessionByTrackerAndVisitor(ctx context.Context, trackerID, visitorID string) (*models.WebSession, error) {
+	span, ctx := telemetry.StartPostgresSpan(ctx, "webSessionRepository.GetActiveSessionByTrackerAndVisitor")
+	defer span.Finish()
+	span.LogKV("trackerID", trackerID, "visitorID", visitorID)
+
+	tenant := utils.GetTenantFromContext(ctx)
+
+	var session models.WebSession
+
+	err := r.read.WithContext(ctx).
+		Where("tracker_id = ? AND visitor_id = ? AND tenant = ? AND is_active = ?",
+			trackerID, visitorID, tenant, true).
+		First(&session).Error
+
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			span.LogKV("result.found", false)
+			return nil, nil
+		}
+		span.TraceError(err)
+		return nil, fmt.Errorf("failed to get active session: %w", err)
+	}
+
+	span.LogKV("result.ID", session.ID)
+	return &session, nil
 }

--- a/internal/telemetry/helpers.go
+++ b/internal/telemetry/helpers.go
@@ -557,24 +557,6 @@ func LogDebug(ctx context.Context, msg string, fields ...log.Field) {
 	}
 }
 
-// Error Handling
-func TagError(span opentracing.Span, err error) {
-	if err != nil {
-		// Add standard error tags
-		span.SetTag("error", true)
-
-		// Add OpenTelemetry specific tags
-		span.SetTag("otel.status_code", "error")
-		span.SetTag("otel.status_message", err.Error())
-
-		span.LogFields(
-			log.Error(err),
-			log.String("event", "error"),
-			log.String("time", time.Now().Format(time.RFC3339)),
-		)
-	}
-}
-
 func (s *Spans) TraceError(err error) {
 	if s == nil || err == nil {
 		return

--- a/services/content_profiler/service.go
+++ b/services/content_profiler/service.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"strings"
 	"time"
 
 	"github.com/nats-io/nats.go"
@@ -152,14 +151,15 @@ func (s *contentProfiler) processMessage(ctx context.Context, msg *nats.Msg) {
 	}
 
 	// Process the email
-	err = s.handleNewTrackerCreated(ctx, message)
-	if err != nil {
-		if !strings.Contains(err.Error(), "skipping") {
-			spans.TraceError(err)
-		}
-		s.handleProcessingError(ctx, msg, err)
-		return
-	}
+	// TODO implement this
+	// err = s.handleNewTrackerCreated(ctx, message)
+	// if err != nil {
+	// 	if !strings.Contains(err.Error(), "skipping") {
+	// 		spans.TraceError(err)
+	// 	}
+	// 	s.handleProcessingError(ctx, msg, err)
+	// 	return
+	// }
 
 	msg.Ack()
 	return

--- a/services/init.go
+++ b/services/init.go
@@ -3,6 +3,7 @@ package services
 import (
 	"context"
 
+	"github.com/customeros/leads/interfaces"
 	"github.com/customeros/leads/internal/config"
 	"github.com/customeros/leads/internal/database"
 	nats_internal "github.com/customeros/leads/internal/nats"
@@ -22,7 +23,7 @@ type Services struct {
 	ProxyManager      proxy_manager.ProxyManagerService
 	SessionManager    session_manager.SessionManager
 	SnitcherService   *snitcher.SnitcherService
-	WebEventProcessor web_event_processor.WebEventProcessor
+	WebEventProcessor interfaces.WebEventProcessor
 	WebtrackerService webtracker.WebtrackerService
 }
 

--- a/services/scraper/jina.go
+++ b/services/scraper/jina.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/customeros/mailsherpa/domaincheck"
 
@@ -156,9 +157,10 @@ func (s *scraperService) fetchPageWithJina(ctx context.Context, url string) (str
 	req.Header.Set("X-With-Links-Summary", "true") // Include links summary
 
 	// Add a timeout
-	client := clients.NewLoggingClient(s.repositories.APICallLogRepository, enum.VendorJina)
+	clientTimeout := 15 * time.Second
+	httpClient := clients.NewLoggingClient(s.repositories.APICallLogRepository, enum.VendorJina, &clientTimeout)
 
-	resp, err := client.Do(req)
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		spans.TraceError(err)
 		return "", err

--- a/services/session_analyzer/analyze_session.go
+++ b/services/session_analyzer/analyze_session.go
@@ -47,7 +47,7 @@ func (s *sessionAnalyzer) determineLeadSource(ctx context.Context, href, referre
 
 	parsedReferrer, err := utils.ParseURL(referrer)
 	if err != nil {
-		spans.TraceError(err)
+		span.TraceError(err)
 		return leadSource, nil
 	}
 
@@ -57,7 +57,7 @@ func (s *sessionAnalyzer) determineLeadSource(ctx context.Context, href, referre
 
 	parsedHref, err := utils.ParseURL(href)
 	if err != nil {
-		spans.TraceError(err)
+		span.TraceError(err)
 		return leadSource, nil
 	}
 

--- a/services/web_event_processor/process.go
+++ b/services/web_event_processor/process.go
@@ -34,12 +34,18 @@ func (s *webEventProcessor) Process(ctx context.Context, webtrackerID string, ev
 		return
 	}
 
-	// get SessionID
-	sessionID, err := s.natsConn.SessionCache.Get(ctx, webtrackerID, event.VisitorId)
+	// get active web session
+	sessionID := ""
+	webSession, err := s.repositories.WebSessionRepository.GetActiveSessionByTrackerAndVisitor(ctx, webtrackerID, event.VisitorId)
 	if err != nil {
 		span.TraceError(err)
 		return
 	}
+
+	if webSession != nil {
+		sessionID = webSession.ID
+	}
+
 	if sessionID == "" {
 		sessionID, err = s.newSession(ctx, webtrackerID, event)
 		if err != nil {
@@ -82,11 +88,7 @@ func (s *webEventProcessor) newSession(ctx context.Context, webtrackerID string,
 	span, ctx := telemetry.StartServiceSpan(ctx, "webEventProcessor.newSession")
 	defer span.Finish()
 
-	sessionID, err := s.createNewSessionID(ctx, webtrackerID, event)
-	if err != nil {
-		span.TraceError(err)
-		return "", err
-	}
+	sessionID := utils.GenerateNanoIDWithPrefix("sess", 21)
 
 	webSessionEvent := &pb.WebtrackerSessionNew{
 		SessionId: sessionID,
@@ -192,22 +194,6 @@ func (s *webEventProcessor) createWebtrackerEvent(ctx context.Context, webtracke
 	}
 
 	return nil
-}
-
-func (s *webEventProcessor) createNewSessionID(ctx context.Context, webtrackerID string, event *pb.WebTrackerEvent) (string, error) {
-	span, ctx := telemetry.StartServiceSpan(ctx, "webEventProcessor.createNewSessionID")
-	defer span.Finish()
-	span.LogKV("webtrackerID", webtrackerID)
-
-	// generate new ID
-	sessionID := utils.GenerateNanoIDWithPrefix("sess", 21)
-	err := s.natsConn.SessionCache.Set(ctx, webtrackerID, event.VisitorId, sessionID)
-	if err != nil {
-		span.TraceError(err)
-		return "", err
-	}
-
-	return sessionID, nil
 }
 
 func mapWebtrackerToLeadEvent(e enum.WebTrackerEvent) enum.Events {

--- a/services/web_event_processor/service.go
+++ b/services/web_event_processor/service.go
@@ -3,7 +3,7 @@ package web_event_processor
 import (
 	"gorm.io/gorm"
 
-	interfaces "github.com/customeros/leads/interfaces"
+	"github.com/customeros/leads/interfaces"
 	nats_internal "github.com/customeros/leads/internal/nats"
 	"github.com/customeros/leads/internal/repository"
 )

--- a/services/web_event_processor/service.go
+++ b/services/web_event_processor/service.go
@@ -1,18 +1,12 @@
 package web_event_processor
 
 import (
-	"context"
-
 	"gorm.io/gorm"
 
+	interfaces "github.com/customeros/leads/interfaces"
 	nats_internal "github.com/customeros/leads/internal/nats"
 	"github.com/customeros/leads/internal/repository"
-	"github.com/customeros/leads/proto/pb"
 )
-
-type WebEventProcessor interface {
-	Process(ctx context.Context, webtrackerID string, event *pb.WebTrackerEvent)
-}
 
 type webEventProcessor struct {
 	natsConn     *nats_internal.NATSConnections
@@ -24,7 +18,7 @@ func NewWebEventProcessor(
 	natsConn *nats_internal.NATSConnections,
 	leadsWriteDB *gorm.DB,
 	repositories *repository.Repositories,
-) WebEventProcessor {
+) interfaces.WebEventProcessor {
 	return &webEventProcessor{
 		natsConn:     natsConn,
 		leadsWriteDB: leadsWriteDB,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Deprecates NATS session caching, introduces `WebEventProcessor` interface, and shifts to database-backed session management.
> 
>   - **Deprecation**:
>     - `SessionCache` in `session_cache.go` marked as deprecated.
>   - **Web Event Processing**:
>     - Introduces `WebEventProcessor` interface in `web_event_processor.go`.
>     - Updates `webEventProcessor` to implement `WebEventProcessor` interface.
>     - Replaces NATS session cache with database-backed session management in `process.go`.
>   - **Database Changes**:
>     - Adds `GetActiveSessionByTrackerAndVisitor()` to `websession.go` for active session retrieval.
>     - Adds `Active` and `UpdatedAt` fields to `WebSession` in `websession.go`.
>   - **Miscellaneous**:
>     - Removes `TagError()` from `helpers.go`.
>     - Minor refactoring and logging improvements in `jina.go` and `analyze_session.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fleads&utm_source=github&utm_medium=referral)<sup> for d88f0dc4e9e704943be03ce9f5bab429b4501aed. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->