### PR TITLE
patch: do not fail cname check

### DIFF
--- a/internal/repository/webtracker.go
+++ b/internal/repository/webtracker.go
@@ -343,6 +343,7 @@ func (r *webTrackerRepository) GetCNAMEChecks(ctx context.Context) ([]models.Web
 		return nil, err
 	}
 
+	span.LogKV("result.count", len(trackers))
 	return trackers, nil
 }
 

--- a/services/proxy_manager/check_cname.go
+++ b/services/proxy_manager/check_cname.go
@@ -62,11 +62,11 @@ func (s *proxyManagerService) CheckCNAME(ctx context.Context) {
 func (s *proxyManagerService) isCNAMEActive(ctx context.Context, cnameHost, domain, cnameTarget string) (bool, error) {
 	span, ctx := telemetry.StartServiceSpan(ctx, "proxyManagerService.isCNAMEActive")
 	defer span.Finish()
+	span.LogKV("cnameHost", cnameHost, "domain", domain, "cnameTarget", cnameTarget)
 
 	dnsRecord, err := s.getDNSRecord(ctx, cnameHost, domain)
 	if err != nil {
-		span.TraceError(err)
-		return false, err
+		return false, nil
 	}
 
 	// Look for CNAME records in the answer
@@ -159,12 +159,14 @@ func (s *proxyManagerService) handleCNAMENotConfigured(ctx context.Context, trac
 func (s *proxyManagerService) getDNSRecord(ctx context.Context, cnameHost, domain string) ([]dns.RR, error) {
 	span, ctx := telemetry.StartServiceSpan(ctx, "proxyManagerService.getCNAMERecord")
 	defer span.Finish()
+	span.LogKV("cnameHost", cnameHost, "domain", domain)
 
 	c := dns.Client{}
 	m := dns.Msg{}
 
 	// Ensure subdomain ends with a dot
 	host := fmt.Sprintf("%s.%s.", cnameHost, domain)
+	span.LogKV("host", host)
 
 	// Set up the DNS query for CNAME
 	m.SetQuestion(host, dns.TypeCNAME)
@@ -177,10 +179,9 @@ func (s *proxyManagerService) getDNSRecord(ctx context.Context, cnameHost, domai
 		return nil, fmt.Errorf("DNS query failed: %w", err)
 	}
 
-	// Check response code
+	span.LogKV("result.Rcode", r.Rcode)
 	if r.Rcode != dns.RcodeSuccess {
-		err := fmt.Errorf("DNS query returned non-success code: %d", r.Rcode)
-		span.TraceError(err)
+		err = fmt.Errorf("DNS query returned non-success code: %d", r.Rcode)
 		return nil, err
 	}
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Modify CNAME check behavior to prevent failures on missing DNS records and enhance logging in `check_cname.go` and `webtracker.go`.
> 
>   - **Behavior**:
>     - `isCNAMEActive()` in `check_cname.go` now returns `false` instead of an error when DNS records are not found.
>     - `getDNSRecord()` in `check_cname.go` logs the DNS query result code and returns an error only if the result code is not successful.
>   - **Logging**:
>     - Added logging of `cnameHost`, `domain`, and `cnameTarget` in `isCNAMEActive()` in `check_cname.go`.
>     - Added logging of `host` and `result.Rcode` in `getDNSRecord()` in `check_cname.go`.
>     - Added logging of `result.count` in `GetCNAMEChecks()` in `webtracker.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fleads&utm_source=github&utm_medium=referral)<sup> for d160df9c03d6693d5b3a046b46d3d5de8128860f. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->