### PR TITLE
patch: set span name as attribute

### DIFF
--- a/internal/telemetry/helpers.go
+++ b/internal/telemetry/helpers.go
@@ -99,6 +99,7 @@ func startSpan(ctx context.Context, operationName string, opts ...SpanOptions) (
 	} else {
 		otelCtx, otelSpan = tracer.Start(ctx, operationName)
 	}
+	otelSpan.SetAttributes(attribute.String("name", operationName))
 
 	otelSpan.SetAttributes(
 		attribute.String("service.name", "leads"),


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Set OpenTelemetry span attribute `name` to `operationName` in `startSpan()` in `helpers.go`.
> 
>   - **Telemetry**:
>     - In `startSpan()` in `helpers.go`, set OpenTelemetry span attribute `name` to `operationName`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fleads&utm_source=github&utm_medium=referral)<sup> for 4eed3d794233db73696670337e5efa5eef79a495. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->