### PR TITLE
patch: find webtracker by origin

### DIFF
--- a/services/webtracker/get_webtracker.go
+++ b/services/webtracker/get_webtracker.go
@@ -30,11 +30,22 @@ func (s *webtrackerService) IsCNAMEConfigured(ctx context.Context, webtrackerID 
 func (s *webtrackerService) GetWebtrackerByOrigin(ctx context.Context, origin string) (*models.WebTracker, error) {
 	span, ctx := telemetry.StartServiceSpan(ctx, "webtrackerService.GetWebtrackerByOrigin")
 	defer span.Finish()
-	span.LogKV("origin", origin)
+	span.LogKV("origin", origin) // dashb...
+
+	// step 1: get web tracker by origin
+	tracker, err := s.repositories.WebTracker.GetByDomain(ctx, origin)
+	if err != nil {
+		span.TraceError(err)
+		return nil, err
+	}
+	if tracker != nil {
+		return tracker, nil
+	}
 
 	// extract domain from origin
 	domain := utils.ExtractDomain(origin)
 
+	// step 2: get web tracker by domain
 	return s.repositories.WebTracker.GetByDomain(ctx, domain)
 }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> `GetWebtrackerByOrigin` in `get_webtracker.go` now attempts retrieval by full origin first, then by domain if necessary.
> 
>   - **Behavior**:
>     - `GetWebtrackerByOrigin` in `get_webtracker.go` now first attempts to retrieve a web tracker by the full `origin`.
>     - If no tracker is found by `origin`, it extracts the domain and attempts to retrieve by `domain`.
>   - **Error Handling**:
>     - Logs errors using `span.TraceError` if retrieval by `origin` fails.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fleads&utm_source=github&utm_medium=referral)<sup> for b4fb49dca5120ad554971c1723f7375e61eaaec5. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->