### PR TITLE
patch: drop request_id from api_call_logs

### DIFF
--- a/internal/clients/http_logger.go
+++ b/internal/clients/http_logger.go
@@ -39,8 +39,6 @@ type dbLoggingTransport struct {
 }
 
 func (t *dbLoggingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	requestID := utils.GenerateNanoIDWithPrefix("api", 21)
-
 	// Capture request body for logging
 	var requestBodyBytes []byte
 	if req.Body != nil && req.Header.Get("Content-Type") != "multipart/form-data" {
@@ -70,7 +68,6 @@ func (t *dbLoggingTransport) RoundTrip(req *http.Request) (*http.Response, error
 		Vendor:      t.vendor,
 		Method:      req.Method,
 		URL:         req.URL.String(),
-		RequestID:   requestID,
 		RequestBody: requestBodyBytes,
 		Timestamp:   start,
 		Duration:    durationMs,

--- a/internal/models/api_log.go
+++ b/internal/models/api_log.go
@@ -15,7 +15,6 @@ type APICallLog struct {
 	Vendor       enum.APIVendor `gorm:"column:vendor;type:varchar(255);index;not null"`
 	Method       string         `gorm:"column:method;type:varchar(255);not null"`
 	URL          string         `gorm:"column:url;type:varchar(255);not null"`
-	RequestID    string         `gorm:"column:request_id;type:varchar(55);not null"`
 	RequestBody  []byte         `gorm:"column:request_body;type:bytea"`
 	Duration     int            `gorm:"column:duration;type:int;not null"`
 	StatusCode   *int           `gorm:"column:status_code;type:int;not null"`
@@ -101,7 +100,6 @@ func initAPICallLogTable(db *gorm.DB) error {
 	if err := db.Exec(`
 		CREATE INDEX IF NOT EXISTS idx_api_call_logs_vendor_timestamp ON api_call_logs (vendor, timestamp DESC);
 		CREATE INDEX IF NOT EXISTS idx_api_call_logs_status_timestamp ON api_call_logs (status_code, timestamp DESC);
-		CREATE INDEX IF NOT EXISTS idx_api_call_logs_request_id ON api_call_logs (request_id);
 		CREATE INDEX IF NOT EXISTS idx_api_call_logs_timestamp_duration ON api_call_logs (timestamp DESC, duration) 
 			WHERE duration > 1000; -- Index for slow API calls (over 1 second)
 	`).Error; err != nil {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Remove `request_id` from API call logs and associated database schema.
> 
>   - **Behavior**:
>     - Removes `request_id` generation and logging in `RoundTrip()` in `http_logger.go`.
>   - **Models**:
>     - Removes `RequestID` field from `APICallLog` in `api_log.go`.
>     - Deletes index `idx_api_call_logs_request_id` in `initAPICallLogTable()` in `api_log.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fleads&utm_source=github&utm_medium=referral)<sup> for d960afd0af2a46480ed01396a506b6dbcdf50e01. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->