### PR TITLE
patch: set operation name as tag

### DIFF
--- a/internal/telemetry/helpers.go
+++ b/internal/telemetry/helpers.go
@@ -99,7 +99,7 @@ func startSpan(ctx context.Context, operationName string, opts ...SpanOptions) (
 	} else {
 		otelCtx, otelSpan = tracer.Start(ctx, operationName)
 	}
-	otelSpan.SetAttributes(attribute.String("name", operationName))
+	otelSpan.SetAttributes(attribute.String("operation.name", operationName))
 
 	otelSpan.SetAttributes(
 		attribute.String("service.name", "leads"),


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change operation name attribute from `name` to `operation.name` in OpenTelemetry spans in `helpers.go`.
> 
>   - **Behavior**:
>     - Change `otelSpan.SetAttributes` in `startSpan()` in `helpers.go` to set `operation.name` instead of `name` for operation name attribute.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fleads&utm_source=github&utm_medium=referral)<sup> for 953623e8b843ce7dbbe3d8ad7be8b0c9c0f9d72c. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->