### PR TITLE
patch: process snitcher

### DIFF
--- a/internal/telemetry/helpers.go
+++ b/internal/telemetry/helpers.go
@@ -32,6 +32,7 @@ const otelSpanKey contextKey = "otel_span"
 const (
 	ComponentPostgres = "postgres"
 	ComponentService  = "service"
+	ComponentListener = "listener"
 	ComponentCronJob  = "cron"
 	ComponentRest     = "rest"
 	ComponentGraphQL  = "graphql"
@@ -178,6 +179,13 @@ func StartServiceSpan(ctx context.Context, operationName string, opts ...SpanOpt
 	return spans, ctx
 }
 
+func StartListenerSpan(ctx context.Context, operationName string, opts ...SpanOptions) (*Spans, context.Context) {
+	spans, ctx := startSpan(ctx, operationName, opts...)
+	TagComponentListener(spans)
+	SetSpanKindConsumer(spans)
+	return spans, ctx
+}
+
 func StartRestSpan(ctx context.Context, operationName string, opts ...SpanOptions) (*Spans, context.Context) {
 	spans, ctx := startSpan(ctx, operationName, opts...)
 	TagComponentRest(spans)
@@ -209,6 +217,15 @@ func TagComponentService(spans *Spans) {
 	}
 	if spans.OTel != nil {
 		spans.OTel.SetAttributes(attribute.String(componentKey, ComponentService))
+	}
+}
+
+func TagComponentListener(spans *Spans) {
+	if spans == nil {
+		return
+	}
+	if spans.OTel != nil {
+		spans.OTel.SetAttributes(attribute.String(componentKey, ComponentListener))
 	}
 }
 

--- a/services/init.go
+++ b/services/init.go
@@ -36,6 +36,7 @@ func (s *Services) Start(ctx context.Context) error {
 		starter func(context.Context) error
 	}{
 		{"Session Manager Service", s.SessionManager.Start},
+		{"Snitcher Service", s.SnitcherService.Start},
 	}
 
 	for _, svc := range services {
@@ -53,6 +54,7 @@ func (s *Services) Stop(ctx context.Context) {
 		stopper func(context.Context)
 	}{
 		{"Session Manager Service", func(ctx context.Context) { s.SessionManager.Stop() }},
+		{"Snitcher Service", func(ctx context.Context) { s.SnitcherService.Stop() }},
 	}
 
 	for _, service := range services {

--- a/services/snitcher/service.go
+++ b/services/snitcher/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"time"
 
 	"github.com/nats-io/nats.go"
@@ -19,10 +20,9 @@ import (
 )
 
 type SnitcherService struct {
-	config        *config.SnitcherConfig
-	natsConn      *nats_internal.NATSConnections
-	repositories  *repository.Repositories
-	subscriptions []*nats.Subscription
+	config       *config.SnitcherConfig
+	natsConn     *nats_internal.NATSConnections
+	repositories *repository.Repositories
 }
 
 func NewSnitcherService(config *config.SnitcherConfig, repos *repository.Repositories, natsConn *nats_internal.NATSConnections) *SnitcherService {
@@ -36,40 +36,85 @@ func NewSnitcherService(config *config.SnitcherConfig, repos *repository.Reposit
 var SUBSCRIBED_SUBJECT = enum.EventAskSnitcher.String()
 
 const (
-	HTTP_TIMEOUT      = 60 * time.Second
 	MAX_RESPONSE_SIZE = 1 * 1024 * 1024
+
+	// consumer config
+	CONSUMER_NAME         = "snitcher-consumer"
+	ACK_WAIT              = 30 * time.Second
+	MAX_DELIVERY_ATTEMPTS = 5
+	MAX_ACK_PENDING       = 100
 )
 
-// Start begins listening for  events
+// Start begins listening for events using JetStream consumer
 func (s *SnitcherService) Start(ctx context.Context) error {
 	spans, ctx := telemetry.StartServiceSpan(ctx, "SnitcherService.Start")
 	defer spans.Finish()
 
-	// Create a subscription for handling requests
-	sub, err := s.natsConn.Conn.Subscribe(SUBSCRIBED_SUBJECT, func(msg *nats.Msg) {
-		s.handleNatsMessage(ctx, msg)
+	// Create durable consumer for processing
+	_, err := s.natsConn.JS.AddConsumer(nats_internal.LEADS_STREAM, &nats.ConsumerConfig{
+		Durable:       CONSUMER_NAME,
+		AckPolicy:     nats.AckExplicitPolicy,
+		AckWait:       ACK_WAIT,
+		MaxDeliver:    MAX_DELIVERY_ATTEMPTS,
+		FilterSubject: SUBSCRIBED_SUBJECT,
+		MaxAckPending: MAX_ACK_PENDING,
+		DeliverPolicy: nats.DeliverAllPolicy,
 	})
+	if err != nil {
+		spans.TraceError(err)
+		return fmt.Errorf("failed to create consumer: %w", err)
+	}
+
+	// Create pull subscription
+	sub, err := s.natsConn.JS.PullSubscribe(
+		SUBSCRIBED_SUBJECT,
+		CONSUMER_NAME,
+		nats.Bind(nats_internal.LEADS_STREAM, CONSUMER_NAME),
+	)
 	if err != nil {
 		spans.TraceError(err)
 		return fmt.Errorf("failed to create subscription: %w", err)
 	}
 
-	// Keep track of subscription for cleanup
-	s.subscriptions = append(s.subscriptions, sub)
-
-	// Listen for context cancellation to clean up
-	go func() {
-		<-ctx.Done()
-		for _, sub := range s.subscriptions {
-			sub.Unsubscribe()
-		}
-	}()
+	// Start processing
+	go s.processMessages(ctx, sub)
 
 	return nil
 }
 
+// processMessages continuously processes messages one at a time
+func (s *SnitcherService) processMessages(ctx context.Context, sub *nats.Subscription) {
+	log.Println("Snitcher Service started")
+	for {
+		select {
+		case <-ctx.Done():
+			log.Println("Snitcher Service shutting down")
+			return
+		default:
+			// Fetch single message with timeout
+			msgs, err := sub.Fetch(1, nats.MaxWait(1*time.Second))
+			if err != nil {
+				if errors.Is(err, nats.ErrTimeout) {
+					// No messages available, this is normal
+					continue
+				}
+				log.Printf("Fetch error: %v", err)
+				time.Sleep(100 * time.Millisecond) // Small backoff on error
+				continue
+			}
+
+			// Process single message
+			if len(msgs) > 0 {
+				msgCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
+				s.handleNatsMessage(msgCtx, msgs[0])
+				cancel()
+			}
+		}
+	}
+}
+
 // Close gracefully shuts down the service
-func (s *SnitcherService) Close() {
+func (s *SnitcherService) Stop() {
 	if s.natsConn != nil {
 		s.natsConn.Close()
 	}
@@ -78,7 +123,7 @@ func (s *SnitcherService) Close() {
 
 func (s *SnitcherService) handleNatsMessage(ctx context.Context, msg *nats.Msg) {
 	ctx = utils.WithCustomContextFromNats(ctx, msg)
-	spans, ctx := telemetry.StartServiceSpan(ctx, "SnitcherService.handleNatsMessage")
+	spans, ctx := telemetry.StartListenerSpan(ctx, "SnitcherService.handleNatsMessage")
 	defer spans.Finish()
 
 	if msg == nil {
@@ -97,16 +142,19 @@ func (s *SnitcherService) handleNatsMessage(ctx context.Context, msg *nats.Msg) 
 		resp.ErrorMessage = errMsg
 		s.sendResponse(ctx, msg, resp)
 		spans.TraceError(err)
+		msg.Ack()
 		return
 	}
 
 	resp = s.AskSnitcher(ctx, request.IpAddress)
 	if resp == nil {
 		spans.TraceError(errors.New("empty response"))
+		msg.Ack()
 		return
 	}
 
 	s.sendResponse(ctx, msg, resp)
+	msg.Ack()
 }
 
 func (s *SnitcherService) sendResponse(ctx context.Context, req *nats.Msg, resp *pb.IPAddressIdentifyResponse) {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Introduces `SnitcherService` for message processing with JetStream consumer and adds telemetry support for better observability.
> 
>   - **SnitcherService**:
>     - Introduces `SnitcherService` in `services/snitcher/service.go` to process messages using JetStream consumer.
>     - Implements `Start()` to create a durable consumer and pull subscription for `SUBSCRIBED_SUBJECT`.
>     - Adds `processMessages()` to fetch and process messages, acknowledging them post-processing.
>     - Replaces `Close()` with `Stop()` to shut down the service.
>   - **Telemetry**:
>     - Adds `StartListenerSpan()` and `TagComponentListener()` in `internal/telemetry/helpers.go` for listener-specific spans.
>     - Updates `handleNatsMessage()` to use `StartListenerSpan()` for telemetry.
>   - **Service Initialization**:
>     - Updates `Start()` and `Stop()` in `services/init.go` to include `SnitcherService`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fleads&utm_source=github&utm_medium=referral)<sup> for f5905e9ad43cead3470ea9b87cefa0cc391abdcc. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->