### PR TITLE
patch: spans over nats

### DIFF
--- a/internal/telemetry/nats.go
+++ b/internal/telemetry/nats.go
@@ -2,10 +2,12 @@ package telemetry
 
 import (
 	"context"
+	"strings"
 
 	"github.com/nats-io/nats.go"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // InjectTraceContextIntoNatsMsg injects the current trace context into NATS message headers
@@ -18,6 +20,20 @@ func InjectTraceContextIntoNatsMsg(ctx context.Context, msg *nats.Msg) {
 	if msg.Header == nil {
 		msg.Header = nats.Header{}
 	}
+
+	// Get the current span context
+	spanCtx := trace.SpanContextFromContext(ctx)
+	if !spanCtx.IsValid() {
+		// Try to get span from context value
+		if span, ok := ctx.Value(otelSpanKey).(trace.Span); ok && span != nil {
+			spanCtx = span.SpanContext()
+		} else {
+			return
+		}
+	}
+
+	// Create a context with just the span context
+	ctx = trace.ContextWithSpanContext(context.Background(), spanCtx)
 
 	// Get the propagator and inject the context into headers
 	propagator := otel.GetTextMapPropagator()
@@ -34,5 +50,37 @@ func ExtractTraceContextFromNatsMsg(ctx context.Context, msg *nats.Msg) context.
 	// Get the propagator and extract the context from headers
 	propagator := otel.GetTextMapPropagator()
 	carrier := propagation.HeaderCarrier(msg.Header)
-	return propagator.Extract(ctx, carrier)
+
+	// Extract into a new context to avoid mixing with existing context
+	extractedCtx := propagator.Extract(context.Background(), carrier)
+
+	// Get the span context from the extracted context
+	spanCtx := trace.SpanContextFromContext(extractedCtx)
+	if !spanCtx.IsValid() {
+		// Try to get the traceparent header directly
+		traceparent := msg.Header.Get("traceparent")
+		if traceparent != "" {
+			// The traceparent format is: version-traceid-spanid-flags
+			parts := strings.Split(traceparent, "-")
+			if len(parts) >= 4 {
+				if traceID, err := trace.TraceIDFromHex(parts[1]); err == nil {
+					if spanID, err := trace.SpanIDFromHex(parts[2]); err == nil {
+						// Create a new span context with the parsed values
+						spanCtx = trace.NewSpanContext(trace.SpanContextConfig{
+							TraceID:    traceID,
+							SpanID:     spanID,
+							TraceFlags: trace.FlagsSampled,
+						})
+					}
+				}
+			}
+		}
+	}
+
+	if !spanCtx.IsValid() {
+		return ctx
+	}
+
+	// Create a new context with the extracted span context
+	return trace.ContextWithSpanContext(ctx, spanCtx)
 }

--- a/services/session_manager/new_session.go
+++ b/services/session_manager/new_session.go
@@ -202,10 +202,10 @@ func (s *sessionManager) identifyIP(ctx context.Context, ipAddress string) (stri
 	msg.Header = nats.Header{
 		enum.TENANT_HEADER: []string{utils.GetTenantFromContext(ctx)},
 	}
-	msg.Data = reqData
-
 	// Inject trace context into NATS message
 	telemetry.InjectTraceContextIntoNatsMsg(ctx, msg)
+
+	msg.Data = reqData
 
 	resp, err := s.natsConn.Conn.RequestMsg(msg, REQUEST_TIMEOUT)
 	if err != nil {
@@ -246,9 +246,11 @@ func (s *sessionManager) profileIP(ctx context.Context, ipAddress string) (*pb.I
 	// Send request to service
 	msg := nats.NewMsg(enum.EventAskIPData.String())
 	msg.Header = nats.Header{
-		enum.TENANT_HEADER:  []string{utils.GetTenantFromContext(ctx)},
-		enum.USER_ID_HEADER: []string{utils.GetUserIdFromContext(ctx)},
+		enum.TENANT_HEADER: []string{utils.GetTenantFromContext(ctx)},
 	}
+	// Inject trace context into NATS message
+	telemetry.InjectTraceContextIntoNatsMsg(ctx, msg)
+
 	msg.Data = reqData
 
 	resp, err := s.natsConn.Conn.RequestMsg(msg, REQUEST_TIMEOUT)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhance trace context handling for NATS messages in `nats.go` and update `new_session.go` to inject trace context before sending requests.
> 
>   - **Trace Context Handling**:
>     - In `nats.go`, `InjectTraceContextIntoNatsMsg` now ensures a valid span context is used, falling back to `otelSpanKey` if necessary.
>     - `ExtractTraceContextFromNatsMsg` in `nats.go` now attempts to parse `traceparent` header if span context is invalid.
>   - **Session Manager Updates**:
>     - In `new_session.go`, `identifyIP` and `profileIP` functions now inject trace context into NATS messages before sending requests.
>     - Adjusted message data assignment in `identifyIP` to occur after trace context injection.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fleads&utm_source=github&utm_medium=referral)<sup> for af6454c6df14b888af4106b239fd9b7cbc8ca2ed. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->