### PR TITLE
patch: fix query session error

### DIFF
--- a/internal/models/websession.go
+++ b/internal/models/websession.go
@@ -21,7 +21,7 @@ type WebSession struct {
 
 	// Session timing
 	StartedAt       time.Time  `gorm:"column:started_at;type:timestamptz;not null;index"`
-	LastEventAt     *time.Time `gorm:"column:last_event_at;type:timestamptz;index"`
+	LastEventAt     time.Time  `gorm:"column:last_event_at;type:timestamptz;index"`
 	EndedAt         *time.Time `gorm:"column:ended_at;type:timestamptz"`
 	SessionDuration int        `gorm:"column:session_duration;type:integer"` // in seconds
 

--- a/internal/repository/websession.go
+++ b/internal/repository/websession.go
@@ -107,6 +107,8 @@ func (r *webSessionRepository) CreateWithTxn(ctx context.Context, tx *gorm.DB, s
 		return ErrTrackerIdMissing
 	}
 	span.TagEntity(session.ID)
+	session.StartedAt = utils.NowIfZero(session.StartedAt)
+	session.LastEventAt = utils.NowIfZero(session.LastEventAt)
 
 	session.Tenant = utils.GetTenantFromContext(ctx)
 
@@ -125,7 +127,7 @@ func (r *webSessionRepository) GetActiveSessionsWithLookback(ctx context.Context
 	var sessions []*models.WebSession
 
 	err := r.read.WithContext(ctx).
-		Where("is_active = ? AND timestamp < ?", true, olderThan).
+		Where("is_active = ? AND last_event_at < ?", true, olderThan).
 		Find(&sessions).Error
 	if err != nil {
 		span.TraceError(err)

--- a/internal/repository/webtracker.go
+++ b/internal/repository/webtracker.go
@@ -65,7 +65,12 @@ func (r *webTrackerRepository) Create(ctx context.Context, tracker *models.WebTr
 	}
 
 	result := r.write.WithContext(ctx).Create(tracker)
-	return result.Error
+	if result.Error != nil {
+		span.TraceError(result.Error)
+		return result.Error
+	}
+
+	return nil
 }
 
 func (r *webTrackerRepository) CreateWithTxn(ctx context.Context, txn *gorm.DB, tracker *models.WebTracker) error {
@@ -85,7 +90,13 @@ func (r *webTrackerRepository) CreateWithTxn(ctx context.Context, txn *gorm.DB, 
 		tracker.ID = uuid.New().String()
 	}
 
-	return txn.Create(tracker).Error
+	err := txn.Create(tracker).Error
+	if err != nil {
+		span.TraceError(err)
+		return err
+	}
+
+	return nil
 }
 
 // GetByID retrieves a WebTracker by ID
@@ -110,6 +121,7 @@ func (r *webTrackerRepository) GetByID(ctx context.Context, id string) (*models.
 		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
 			return nil, leads_errors.ErrWebtrackerNotFound
 		}
+		span.TraceError(result.Error)
 		return nil, result.Error
 	}
 	return &tracker, nil
@@ -154,8 +166,13 @@ func (r *webTrackerRepository) GetTrackers(ctx context.Context) ([]models.WebTra
 		Order("domain").
 		Find(&trackers)
 
+	if result.Error != nil {
+		span.TraceError(result.Error)
+		return nil, result.Error
+	}
+
 	span.LogKV("result.count", len(trackers))
-	return trackers, result.Error
+	return trackers, nil
 }
 
 // GetActiveTrackers retrieves all active non-archived WebTrackers
@@ -178,8 +195,13 @@ func (r *webTrackerRepository) GetActiveTrackers(ctx context.Context) ([]models.
 		Order("domain").
 		Find(&trackers)
 
+	if result.Error != nil {
+		span.TraceError(result.Error)
+		return nil, result.Error
+	}
+
 	span.LogKV("result.count", len(trackers))
-	return trackers, result.Error
+	return trackers, nil
 }
 
 // Update updates an existing WebTracker
@@ -225,10 +247,15 @@ func (r *webTrackerRepository) Update(ctx context.Context, dto dto.WebTrackerUpd
 		Where("id = ?", dto.ID).
 		Updates(updates)
 
+	if result.Error != nil {
+		span.TraceError(result.Error)
+		return result.Error
+	}
+
 	if result.RowsAffected == 0 {
 		return errors.New("webtracker not found")
 	}
-	return result.Error
+	return nil
 }
 
 // UpdateLastEventAt updates the LastEventAt timestamp for a specific tracker
@@ -300,10 +327,15 @@ func (r *webTrackerRepository) Archive(ctx context.Context, id string) error {
 			"updated_at":      now,
 		})
 
+	if result.Error != nil {
+		span.TraceError(result.Error)
+		return result.Error
+	}
+
 	if result.RowsAffected == 0 {
 		return errors.New("webtracker not found")
 	}
-	return result.Error
+	return nil
 }
 
 // Restore unarchives a WebTracker
@@ -320,10 +352,15 @@ func (r *webTrackerRepository) Restore(ctx context.Context, id string) error {
 			"updated_at":  now,
 		})
 
+	if result.Error != nil {
+		span.TraceError(result.Error)
+		return result.Error
+	}
+
 	if result.RowsAffected == 0 {
 		return errors.New("webtracker not found")
 	}
-	return result.Error
+	return nil
 }
 
 func (r *webTrackerRepository) GetCNAMEChecks(ctx context.Context) ([]models.WebTracker, error) {
@@ -340,6 +377,7 @@ func (r *webTrackerRepository) GetCNAMEChecks(ctx context.Context) ([]models.Web
 		Where("is_archived = ?", false).
 		Find(&trackers).Error
 	if err != nil {
+		span.TraceError(err)
 		return nil, err
 	}
 
@@ -359,8 +397,13 @@ func (r *webTrackerRepository) CNAMEConfiguredWithTxn(ctx context.Context, txn *
 			"cname_check_count":   0,
 		})
 
+	if result.Error != nil {
+		span.TraceError(result.Error)
+		return result.Error
+	}
+
 	if result.RowsAffected == 0 {
 		return errors.New("webtracker not found")
 	}
-	return result.Error
+	return nil
 }

--- a/services/web_event_processor/process.go
+++ b/services/web_event_processor/process.go
@@ -137,7 +137,7 @@ func (s *webEventProcessor) newSession(ctx context.Context, webtrackerID string,
 			VisitorID:   event.VisitorId,
 			TrackerID:   webtrackerID,
 			StartedAt:   now,
-			LastEventAt: &now,
+			LastEventAt: now,
 		}
 
 		err = s.repositories.WebSession.CreateWithTxn(ctx, tx, &webSession)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix query session error by making `LastEventAt` non-nullable and improving error handling across repositories and services.
> 
>   - **Models**:
>     - Change `LastEventAt` in `WebSession` to non-nullable in `websession.go`.
>   - **Repositories**:
>     - Set `LastEventAt` to current time if zero in `CreateWithTxn()` in `websession.go`.
>     - Update query condition in `GetActiveSessionsWithLookback()` in `websession.go` to use `last_event_at`.
>     - Add error tracing and return nil in `Create()`, `CreateWithTxn()`, `GetByID()`, `GetTrackers()`, `GetActiveTrackers()`, `Update()`, `Archive()`, `Restore()`, `CNAMEConfiguredWithTxn()` in `webtracker.go`.
>   - **Services**:
>     - Update `newSession()` in `process.go` to handle `LastEventAt` as non-nullable.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fleads&utm_source=github&utm_medium=referral)<sup> for b232338624d5a00ae92176d29d902e43a0fcd55d. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->