### PR TITLE
patch: change policy

### DIFF
--- a/internal/nats/nats.go
+++ b/internal/nats/nats.go
@@ -157,7 +157,7 @@ func setupWorkQueueStream(js nats.JetStreamContext, streamName string, subjects 
 		_, err = js.AddStream(&nats.StreamConfig{
 			Name:      streamName,
 			Subjects:  subjects,
-			Retention: nats.WorkQueuePolicy,
+			Retention: nats.InterestPolicy,
 			Storage:   nats.FileStorage,
 			Replicas:  replicas,
 			MaxAge:    168 * time.Hour,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change NATS stream retention policy from `WorkQueuePolicy` to `InterestPolicy` in `nats.go`.
> 
>   - **Behavior**:
>     - Change retention policy from `WorkQueuePolicy` to `InterestPolicy` in `setupWorkQueueStream()` in `nats.go`.
>     - Affects message retention strategy for NATS streams, switching from work queue to interest-based model.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fleads&utm_source=github&utm_medium=referral)<sup> for 059d4b189bcacd01b36ef065150d1072a99ee475. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->