### PR TITLE
patch: fix cron locking

### DIFF
--- a/internal/cron/cron.go
+++ b/internal/cron/cron.go
@@ -41,10 +41,10 @@ var jobLocks = struct {
 	locks map[string]*sync.Mutex
 }{
 	locks: map[string]*sync.Mutex{
-		GroupOutbox:     &sync.Mutex{},
-		GroupProxy:      &sync.Mutex{},
-		GroupWebSession: &sync.Mutex{},
-		GroupWebTracker: &sync.Mutex{},
+		GroupOutbox:     {},
+		GroupProxy:      {},
+		GroupWebSession: {},
+		GroupWebTracker: {},
 	},
 }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Simplify mutex initialization in `cron.go` by using zero-value `{}` for `jobLocks` map.
> 
>   - **Code Simplification**:
>     - In `cron.go`, simplify mutex initialization in `jobLocks` map by removing explicit `&sync.Mutex{}` and using `{}` for `GroupOutbox`, `GroupProxy`, `GroupWebSession`, and `GroupWebTracker`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fleads&utm_source=github&utm_medium=referral)<sup> for b7ce2ecda9b75cfa0ccf3c26658425141ae793bc. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->