### PR TITLE
patch: add tracing to nats response

### DIFF
--- a/services/session_manager/new_session.go
+++ b/services/session_manager/new_session.go
@@ -276,8 +276,16 @@ func (s *sessionManager) profileIP(ctx context.Context, ipAddress string) (*pb.I
 		return nil, errors.Wrap(err, "Nats request failed")
 	}
 
+	span.LogKV("response_received", "true")
+	span.LogKV("response_subject", resp.Subject)
+	span.LogKV("response_reply", resp.Reply)
+	span.LogKV("response_header", fmt.Sprintf("%+v", resp.Header))
 	span.LogKV("response_data_length", len(resp.Data))
 	span.LogKV("response_data_hex", fmt.Sprintf("%x", resp.Data))
+
+	// Try to decode the response data as a string first to see what we got
+	responseStr := string(resp.Data)
+	span.LogKV("response_as_string", responseStr)
 
 	// Unmarshal response
 	response := &pb.IPAddressVerifyResponse{}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhances tracing in `profileIP()` in `new_session.go` by logging detailed NATS response attributes.
> 
>   - **Tracing Enhancements**:
>     - In `profileIP()` in `new_session.go`, added detailed logging for NATS response attributes: `response_subject`, `response_reply`, `response_header`, `response_data_length`, `response_data_hex`, and `response_as_string`.
>     - Logs the response as a string to aid in debugging and understanding the response content.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fleads&utm_source=github&utm_medium=referral)<sup> for 99611724f17d0fb4a66eacc495024ce666d44579. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->