### PR TITLE
patch: request stream as core nats (no jet stream)

### DIFF
--- a/internal/nats/nats.go
+++ b/internal/nats/nats.go
@@ -12,10 +12,11 @@ import (
 )
 
 const (
-	MAX_STREAM_RECONNECTS        = -1 // never stop trying to reconnect
-	DLQ_PREFIX            string = "dlq."
-	HEADER_TENANT         string = "X-Tenant"
-	HEADER_USERID         string = "X-UserId"
+	MAX_STREAM_RECONNECTS                  = -1 // never stop trying to reconnect
+	DLQ_PREFIX            string           = "dlq."
+	HEADER_TENANT         string           = "X-Tenant"
+	HEADER_USERID         string           = "X-UserId"
+	REQUEST_STREAM        enums.NatsStream = enums.StreamRequest
 )
 
 // NATSConnection represents a single NATS connection with its associated JetStream context
@@ -115,7 +116,17 @@ func InitNats(config *config.NATSConfig, environment string, streams []enums.Nat
 		}
 		log.Printf("✅ NATS connection established for stream %s", streamName)
 
-		// Create JetStream context for each stream
+		// Special handling for request stream - use core NATS only
+		if streamName == REQUEST_STREAM {
+			streamConns[streamName] = &NATSConnection{
+				Conn: conn,
+				Name: streamName,
+			}
+			log.Printf("✅ Request stream configured for core NATS (no JetStream)")
+			continue
+		}
+
+		// For all other streams, create JetStream context
 		js, err := conn.JetStream()
 		if err != nil {
 			for _, c := range streamConns {
@@ -133,7 +144,7 @@ func InitNats(config *config.NATSConfig, environment string, streams []enums.Nat
 		}
 
 		// Set up stream
-		err = setupWorkQueueStream(js, streamName.String(), []string{streamName.String() + ".>"}, replicas)
+		err = setupJetStream(js, streamName.String(), []string{streamName.String() + ".>"}, replicas)
 		if err != nil {
 			for _, c := range streamConns {
 				c.Close()
@@ -150,7 +161,7 @@ func InitNats(config *config.NATSConfig, environment string, streams []enums.Nat
 	}, nil
 }
 
-func setupWorkQueueStream(js nats.JetStreamContext, streamName string, subjects []string, replicas int) error {
+func setupJetStream(js nats.JetStreamContext, streamName string, subjects []string, replicas int) error {
 	streamInfo, err := js.StreamInfo(streamName)
 	if err != nil {
 		// Stream doesn't exist, create it


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Handle `REQUEST_STREAM` using core NATS in `InitNats`, bypassing JetStream setup, and rename `setupWorkQueueStream` to `setupJetStream`.
> 
>   - **Behavior**:
>     - `InitNats` in `nats.go` now handles `REQUEST_STREAM` using core NATS only, bypassing JetStream setup.
>     - Logs a message indicating configuration for core NATS when `REQUEST_STREAM` is initialized.
>   - **Constants**:
>     - Adds `REQUEST_STREAM` constant to represent `enums.StreamRequest`.
>   - **Function Renames**:
>     - Renames `setupWorkQueueStream` to `setupJetStream`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fleads&utm_source=github&utm_medium=referral)<sup> for 15da229b9c72248f12cadc5376e6bf4fd4f80c60. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->