### PR TITLE
patch: ignore specific origins

### DIFF
--- a/api/handlers/website_events_handler.go
+++ b/api/handlers/website_events_handler.go
@@ -51,6 +51,16 @@ type WebTrackerEvent struct {
 	ScreenResolution string               `json:"screenResolution"`
 }
 
+func (h *WebsiteEventsHandler) shouldIgnoreOrigin(origin string) bool {
+	// Check for HubSpot preview domain pattern (e.g. 123456789.hubspotpreview-na1.com)
+	if matched := utils.MatchPattern(origin, `^\d+\.hubspotpreview-[a-z0-9]+\.com$`); matched {
+		return true
+	}
+
+	// Add more patterns here
+	return false
+}
+
 func (h *WebsiteEventsHandler) Handle() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		span, ctx := telemetry.StartRestSpan(c.Request.Context(), "WebsiteEventsHandler.Handle")
@@ -62,7 +72,14 @@ func (h *WebsiteEventsHandler) Handle() gin.HandlerFunc {
 			return
 		}
 
-		tenant, webtrackerID, err := h.getTenantAndTrackerID(ctx, c.GetHeader("Origin"))
+		origin := c.GetHeader("Origin")
+		if h.shouldIgnoreOrigin(origin) {
+			span.LogKV("ignored_origin", origin, "reason", "origin pattern ignored")
+			c.JSON(http.StatusOK, gin.H{"ignored": "true", "reason": "origin pattern ignored"})
+			return
+		}
+
+		tenant, webtrackerID, err := h.getTenantAndTrackerID(ctx, origin)
 		if err != nil {
 			span.TraceError(err)
 			c.JSON(http.StatusForbidden, gin.H{"error": "forbidden"})

--- a/internal/utils/string.go
+++ b/internal/utils/string.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"bytes"
+	"regexp"
 	"unicode/utf8"
 )
 
@@ -43,4 +44,13 @@ func IsStringInSlice(s string, slice []string) bool {
 		}
 	}
 	return false
+}
+
+// MatchPattern checks if a string matches a given regex pattern
+func MatchPattern(s, pattern string) bool {
+	matched, err := regexp.MatchString(pattern, s)
+	if err != nil {
+		return false
+	}
+	return matched
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add functionality to ignore specific origins in `WebsiteEventsHandler` using regex pattern matching for HubSpot preview domains.
> 
>   - **Behavior**:
>     - Adds `shouldIgnoreOrigin` method in `WebsiteEventsHandler` to ignore origins matching HubSpot preview domain pattern.
>     - Updates `Handle` method in `website_events_handler.go` to return early if origin is ignored, logging the reason.
>   - **Utils**:
>     - Adds `MatchPattern` function in `string.go` to check if a string matches a regex pattern.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fleads&utm_source=github&utm_medium=referral)<sup> for ddb5b7a9b8d936bc89a383f63f16195930c64e1a. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->